### PR TITLE
Copy nav bars from ubports.com

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -32,6 +32,8 @@ head
                 li
                   a(ng-click='opened = false', href='https://wiki.ubports.com') Wiki
                 li
+                  a(ng-click='opened = false', href='https://blog.ubports.com') Blog
+                li
                   a(ng-click='opened = false', href='https://ubports.com/get-involved') Get Involved
                 li
                   a(ng-click='opened = false', href='https://ubports.com/sponsors') Sponsors
@@ -51,6 +53,8 @@ head
               a(href='https://forums.ubports.com') Forums
             li
               a(href='https://wiki.ubports.com') Wiki
+            li
+              a(href='https://blog.ubports.com') Blog
             li
               a(href='https://ubports.com/get-involved') Get Involved
             li


### PR DESCRIPTION
Added the blog link to the navigation bars on devices.ubports.com, to make it look like the ubports.com landing page. Can we somehow automatically sync these?